### PR TITLE
Fix OpenSSL digital envelope error on Vercel builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,13 @@
     "version": "0.1.0",
     "private": true,
     "scripts": {
-        "dev": "next dev -p 3001",
-        "build": "next build",
+        "dev": "NODE_OPTIONS=--openssl-legacy-provider next dev -p 3001",
+        "build": "NODE_OPTIONS=--openssl-legacy-provider next build",
         "start": "next start",
         "format": "prettier --write **/*.js --config .prettierrc"
+    },
+    "engines": {
+        "node": "22.x"
     },
     "dependencies": {
         "@chakra-ui/react": "^1.1.2",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+    "build": {
+        "env": {
+            "NODE_OPTIONS": "--openssl-legacy-provider"
+        }
+    }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,5 @@
 {
-    "build": {
-        "env": {
-            "NODE_OPTIONS": "--openssl-legacy-provider"
-        }
+    "env": {
+        "NODE_OPTIONS": "--openssl-legacy-provider"
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Vercel builds were failing on Node.js 22 with `ERR_OSSL_EVP_UNSUPPORTED` because Next.js 11's webpack still uses OpenSSL legacy MD4 hashing.

## Changes
- Set `NODE_OPTIONS=--openssl-legacy-provider` on `dev` and `build` scripts
- Add `vercel.json` env with the same option so the Vercel build picks it up
- Pin `engines.node` to `22.x` to match the Vercel runtime that surfaced the error

## Verification
Local `yarn build` on Node 22 completes successfully after this change.

## Test plan
- [x] Confirm local `yarn build` succeeds on Node 22
- [ ] Confirm Vercel production/preview build succeeds after merge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1ab4612-8c8c-41d5-8fb4-29b0facb35a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1ab4612-8c8c-41d5-8fb4-29b0facb35a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

